### PR TITLE
Remove all inline assembly

### DIFF
--- a/libkdump/Makefile
+++ b/libkdump/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-O3 -pthread -Wno-attributes 
+CFLAGS=-O3 -pthread -Wno-attributes -mrtm 
 CC=gcc
 
 all: libkdump.a libkdump.so


### PR DESCRIPTION
GCC, MSVC and CLANG provide intrinsics for all the low-level assembly
operations attempted. Additionally, the 'meltdown sequence' can be
expressed in C code (as per the paper) with the appropriate volatile
statements. Finally, usage of MFENCE is not needed when using RDTSCP as
the latter is already serializing.