### PR TITLE
README 'libkdump_init' call update for KASLR

### DIFF
--- a/libkdump/README.md
+++ b/libkdump/README.md
@@ -117,7 +117,7 @@ config = libkdump_get_autoconfig();
 // change address of direct physical map
 config.physical_offset = 0xffff98a000000000ull;
 // initialize libkdump with custom config
-if(libkdump_init(libkdump_auto_config) != 0) {
+if(libkdump_init(config) != 0) {
 	return -1;
 }
 
@@ -151,7 +151,7 @@ config = libkdump_get_autoconfig();
 // change any property, e.g., direct-physical map offset
 config.physical_offset = 0xffff98a000000000ull;
 // initialize libkdump with custom config
-if(libkdump_init(libkdump_auto_config) != 0) {
+if(libkdump_init(config) != 0) {
 	return -1;
 }
 ```


### PR DESCRIPTION
Updated `libkdump` `README.md`.
When initializing for KASLR, custom `config` variable is created with kernel base address, but `libkdump_init` receives automatic config from `libkdump_auto_config` instead of custom `config` just created.

Signed-off-by: Lukasz Gryglicki <lukaszgryglicki@o2.pl>