### PR TITLE
allow for additional CFLAGS for `make`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-O3 -pthread -Wno-attributes 
+override CFLAGS += -O3 -pthread -Wno-attributes
 CC=gcc
 
 #BINARIES=test kaslr physical_reader
@@ -8,7 +8,7 @@ BINARIES := $(SOURCES:%.c=%)
 
 all: $(BINARIES)
 
-libkdump/libkdump.a: 
+libkdump/libkdump.a:  libkdump/libkdump.c
 	make -C libkdump
 
 %: %.c libkdump/libkdump.a

--- a/libkdump/Makefile
+++ b/libkdump/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-O3 -pthread -Wno-attributes 
+override CFLAGS += -O3 -pthread -Wno-attributes
 CC=gcc
 
 all: libkdump.a libkdump.so


### PR DESCRIPTION
Append our `CFLAGS` to those given by user to the `make`.

Signed-off-by: Pavel Boldin <boldin.pavel@gmail.com>