### PR TITLE
`setjmp` returns 0 on first call, `longjmp` later

### DIFF
--- a/libkdump/libkdump.c
+++ b/libkdump/libkdump.c
@@ -14,7 +14,6 @@
 libkdump_config_t libkdump_auto_config = {0};
 
 // ---------------------------------------------------------------------------
-static volatile size_t run = 1;
 static jmp_buf buf;
 
 static char *_mem = NULL, *mem = NULL;
@@ -360,9 +359,8 @@ static void unblock_signal(int signum __attribute__((__unused__))) {
 // ---------------------------------------------------------------------------
 static void segfault_handler(int signum) {
   (void)signum;
-  run = 0;
   unblock_signal(SIGSEGV);
-  longjmp(buf, 0);
+  longjmp(buf, 1);
 }
 
 // ---------------------------------------------------------------------------
@@ -503,9 +501,7 @@ int __attribute__((optimize("-Os"), noinline)) libkdump_read_signal_handler() {
   uint64_t start = 0, end = 0;
 
   while (retries--) {
-    run = 1;
-    setjmp(buf);
-    if (run) {
+    if (!setjmp(buf)) {
       MELTDOWN;
     }
 


### PR DESCRIPTION
For the signal handler we don't need `run` variable since `setjmp`
returns zero for first call (that sets the frame) and whatever `longjmp`
is called with afterwards.

Signed-off-by: Pavel Boldin <boldin.pavel@gmail.com>