### PR TITLE
Fixed typo in libkdump.h docs

### DIFF
--- a/libkdump/libkdump.h
+++ b/libkdump/libkdump.h
@@ -108,7 +108,7 @@ size_t libkdump_phys_to_virt(size_t addr);
 
 
 /**
- * Retrieves the physical address of a virtual address. Requires root (or read permissions for /proc/self/pagemap).
+ * Enables or disables the debug output of libkdump as required.
  *
  * @param[in] enable Enable (1) or disable (0) the debug output of libkdump. Default is disabled. 
  */


### PR DESCRIPTION
The `libkdump_enable_debug` function had incorrect description above it in `libkdump.h` file. Just corrected the description at line 111.