### PR TITLE
Small fix: should be argv[0] not argv[1] 

### DIFF
--- a/memory_filler.c
+++ b/memory_filler.c
@@ -14,7 +14,7 @@ const char *strings[] = {
 
 int main(int argc, char *argv[]) {
   if (argc != 2) {
-    printf("Usage: %s <gigabytes to fill>\n", argv[1]);
+    printf("Usage: %s <gigabytes to fill>\n", argv[0]);
     return 0;
   }
 


### PR DESCRIPTION
There is a small bug in memory_filler.c when displaying the usage message.