### PR TITLE
Improved `test.c` reliability

### DIFF
--- a/test.c
+++ b/test.c
@@ -1,4 +1,5 @@
 #include "libkdump.h"
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -31,6 +32,8 @@ int main(int argc, char *argv[]) {
   printf("   Got: \x1b[33;1m");
   while (index < strlen(test)) {
     int value = libkdump_read((size_t)(test + index));
+    if (!isprint(value))
+      continue;
     printf("%c", value);
     fflush(stdout);
     index++;


### PR DESCRIPTION
This is done by discarding non-printable readings until we get a char, instead of skipping that position (address).
The original behavior causes everything after that be empty as well, presumably because of a system lag spike at that moment.

This looks fine to me for PoC demo purposes.